### PR TITLE
Disabled autoload for bootstrap.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     "autoload": {
       "psr-4": {
         "Dcode\\Bitrix\\": "src/"
-      },
-      "files": ["bootstrap.php"]
+      }
     },
     "require": {
       "php": ">=5.5.9",


### PR DESCRIPTION
Removed bootstrap.php from composer files section to disable it's auto-include. Was breaking bitrix during development.